### PR TITLE
JacdacDisplay hanging bug fix

### DIFF
--- a/cpp/jddisplay.cpp
+++ b/cpp/jddisplay.cpp
@@ -77,8 +77,7 @@ static void *jd_push_in_frame(jd_frame_t *frame, unsigned service_num, unsigned 
     return dst;
 }
 
-JDDisplay::JDDisplay(SPI *spi, Pin *cs, Pin *flow) : spi(spi), cs(cs), flow(flow) {
-    inProgress = false;
+JDDisplay::JDDisplay(SPI *spi, Pin *cs, Pin *flow) : spi(spi), cs(cs), flow(flow), inProgressLock(1) {
     stepWaiting = false;
     displayServiceNum = 0;
     controlsStartServiceNum = 0;
@@ -91,22 +90,21 @@ JDDisplay::JDDisplay(SPI *spi, Pin *cs, Pin *flow) : spi(spi), cs(cs), flow(flow
     avgFrameTime = 26300; // start with a reasonable default
     lastFrameTimestamp = 0;
 
-    EventModel::defaultEventBus->listen(DEVICE_ID_DISPLAY, 4243, this, &JDDisplay::sendDone);
-
+    // Send data when the DC pin is set high:
     flow->getDigitalValue(PullMode::Down);
     EventModel::defaultEventBus->listen(flow->id, DEVICE_PIN_EVENT_ON_EDGE, this,
                                         &JDDisplay::onFlowHi, MESSAGE_BUS_LISTENER_IMMEDIATE);
     flow->eventOn(DEVICE_PIN_EVT_RISE);
 }
 
-void JDDisplay::waitForSendDone() {
-    if (inProgress)
-        fiber_wait_for_event(DEVICE_ID_DISPLAY, 4242);
-}
 
-void JDDisplay::sendDone(Event) {
-    inProgress = false;
-    Event(DEVICE_ID_DISPLAY, 4242);
+/**
+* Deprecated; no longer neccessary. sendIndexedImage handles this.
+*/
+void JDDisplay::waitForSendDone() {}
+
+void JDDisplay::sendDone(JDDisplay* jdd) {
+    inProgressLock.notify();
 }
 
 void *JDDisplay::queuePkt(uint32_t service_num, uint32_t service_cmd, uint32_t size) {
@@ -321,9 +319,7 @@ void JDDisplay::step() {
         }
         flushSend();
     } else {
-        // trigger sendDone(), which executes outside of IRQ context, so there
-        // is no race with waitForSendDone
-        Event(DEVICE_ID_DISPLAY, 4243);
+        sendDone(this);
     }
 }
 
@@ -333,13 +329,11 @@ int JDDisplay::sendIndexedImage(const uint8_t *src, unsigned width, unsigned hei
         target_panic(123);  // PANIC_SCREEN_ERROR
     if (width != addr.width || height != addr.height)
         target_panic(124); // PANIC_SCREEN_ERROR
-    if (inProgress)
-        target_panic(125); // PANIC_SCREEN_ERROR
 
     if (addr.y && addr.y >= screenHeight)
         return 0; // out of range
 
-    inProgress = true;
+    inProgressLock.wait();
 
     int numcols = JD_SERIAL_PAYLOAD_SIZE / (height / 2);
 

--- a/cpp/jddisplay.h
+++ b/cpp/jddisplay.h
@@ -25,7 +25,9 @@ class JDDisplay {
     jd_frame_t sendFrame;
     jd_frame_t recvFrame;
     uint8_t bytesPerTransfer;
-    bool inProgress;
+
+    FiberLock inProgressLock;
+
     volatile bool stepWaiting;
     uint8_t displayServiceNum;
     uint8_t controlsStartServiceNum;
@@ -43,7 +45,7 @@ class JDDisplay {
     void *queuePkt(uint32_t service_num, uint32_t service_cmd, uint32_t size);
     void flushSend();
     void step();
-    void sendDone(Event);
+    void sendDone(JDDisplay* jdd);
     static void stepStatic(void *);
     void onFlowHi(Event);
     void handleIncoming(jd_packet_t *pkt);

--- a/pxt.json
+++ b/pxt.json
@@ -69,6 +69,7 @@
     "supportedTargets": [
         "microbit"
     ],
+    "preferredEditor": "tsprj",
     "disablesVariants": [
         "mbdal"
     ],
@@ -78,7 +79,6 @@
             "DMESG_SERIAL_DEBUG": 1
         }
     },
-    "preferredEditor": "tsprj",
     "tests": [
         "test.ts"
     ],


### PR DESCRIPTION
Driver fix for the bug affecting microbit-apps where the screen hangs (screen stops updating, but program is still running).

- The fix is an introduction of a FiberLock and removal of Event based loop.
- waitForSendDone is now deprecated.
- There appears to be a slight screen tearing issue present.